### PR TITLE
Auth_Url_No_Endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,14 +71,14 @@ Quickstart
 
 #. Install the software.
 
-#. Ask one of your colleagues for the ``auth-url``, ``client-secret`` and
+#. Ask one of your colleagues for the ``auth-host``, ``client-secret`` and
    ``jump-host`` parameters.
 
 #. Then run the following to upload your key:
 
    .. code-block:: console
 
-       $ cbas -a <AUTH-URL> -s <CLIENT-SECRET> -h <JUMP-HOST> upload
+       $ cbas -a <AUTH-host> -s <CLIENT-SECRET> -h <JUMP-HOST> upload
        ...
 
 #. Then you *should* be able to login, using:
@@ -105,8 +105,8 @@ Usage
                                       '~/.ssh/id_rsa.pub'.
       -p, --password-provider <provider>
                                       Password provider. Default: 'prompt'.
-      -a, --auth-url <auth_url>       Auth-server URL.
       -s, --client-secret <secret>    Special client secret, ask mum.
+      -a, --auth-host <host>          Auth-server host.
       -h, --jump-host <host>          Jump host to connect with.
       --version                       Print version and exit.
       --help                          Show this message and exit.
@@ -143,10 +143,10 @@ password-provider
   ``keyring`` will ask exactly once and then store the password in the system
   keyring.
 
-auth-url
-  The URL to access the auth-server and obtain the token. E.g.
-  ``https://auth-server.example/oauth/token``. (Note that this *includes* the
-  protocol.
+auth-host
+  The hostname of the auth-server. E.g ``auth-server.example``. (Note that, by
+  default this will use ``https://``. However, explict urls, e.g.
+  ``http://auth-server.exmple`` are tolerated.)
 
 client-secret
   A special client secret string needed when communicating with the
@@ -188,7 +188,7 @@ config-file, for example:
 
     username: acid_burn
     ssh-key-file: ~/.ssh/mykey_rsa.pub
-    auth-url: https://auth-server.example/oauth/token
+    auth-host auth-server.example
     client-secret: mysupersecret
     password-provider: keyring
     jump-host: jump-host.example

--- a/README.rst
+++ b/README.rst
@@ -145,8 +145,10 @@ password-provider
 
 auth-host
   The hostname of the auth-server. E.g ``auth-server.example``. (Note that, by
-  default this will use ``https://``. However, explict urls, e.g.
-  ``http://auth-server.example`` are tolerated.)
+  default this will use ``https://`` as scheme and ``/oauth/token`` as
+  endpoint. However, explict urls, e.g.  ``http://auth-server.example`` and
+  explicit endpoints e.g. ``auth-server.example/special/id/auth`` are
+  tolerated.)
 
 client-secret
   A special client secret string needed when communicating with the

--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ password-provider
 auth-host
   The hostname of the auth-server. E.g ``auth-server.example``. (Note that, by
   default this will use ``https://``. However, explict urls, e.g.
-  ``http://auth-server.exmple`` are tolerated.)
+  ``http://auth-server.example`` are tolerated.)
 
 client-secret
   A special client secret string needed when communicating with the

--- a/README.rst
+++ b/README.rst
@@ -155,7 +155,7 @@ client-secret
 jump-host
   The hostname of the jump-host. E.g. ``jump-host.example``. (Note that, by
   default this will use ``https://``. However, explict urls, e.g.
-  ``http://jump-host.exmple`` are tolerated.)
+  ``http://jump-host.example`` are tolerated.)
 
 version
   Display version number and exit.

--- a/build.py
+++ b/build.py
@@ -29,6 +29,7 @@ def set_properties(project):
     project.depends_on('secretstorage')
     project.depends_on('yamlreader')
     project.depends_on('requests')
+    project.depends_on('six')
     project.build_depends_on('requests_mock')
     project.build_depends_on('mock')
     project.build_depends_on('bottle')

--- a/src/cmdlinetest/test_cbas.t
+++ b/src/cmdlinetest/test_cbas.t
@@ -14,7 +14,7 @@
                                     '~/.ssh/id_rsa.pub'.
     -p, --password-provider <provider>
                                     Password provider. Default: 'prompt'.
-    -a, --auth-url <auth_url>       Auth-server URL.
+    -a, --auth-host <host>          Auth-server host.
     -h, --jump-host <host>          Jump host to connect with.
     --version                       Print version and exit.
     --help                          Show this message and exit.
@@ -35,7 +35,7 @@
 # Export the mock urls
 
   $ export JUMP_MOCK=http://localhost:8080
-  $ export AUTH_MOCK=http://localhost:8080/oauth/token
+  $ export AUTH_MOCK=http://localhost:8080
 
 # Make a test home
 

--- a/src/cmdlinetest/test_cbas_config.t
+++ b/src/cmdlinetest/test_cbas_config.t
@@ -13,7 +13,7 @@
 
   $ cbas upload
   Some config options are missing:
-  {'auth_url': None,
+  {'auth_host': None,
    'jump_host': None,
    'password_provider': 'prompt',
    'ssh_key_file': '~/.ssh/id_rsa.pub',
@@ -24,25 +24,25 @@
 
   $ cbas -v upload 
   Default config is:
-  {'auth_url': None,
+  {'auth_host': None,
    'jump_host': None,
    'password_provider': 'prompt',
    'ssh_key_file': '~/.ssh/id_rsa.pub',
    'username': '*'} (glob)
   Values supplied on the command-line are:
-  {'auth_url': None,
+  {'auth_host': None,
    'jump_host': None,
    'password_provider': None,
    'ssh_key_file': None,
    'username': None}
   Final aggregated config:
-  {'auth_url': None,
+  {'auth_host': None,
    'jump_host': None,
    'password_provider': 'prompt',
    'ssh_key_file': '~/.ssh/id_rsa.pub',
    'username': '*'} (glob)
   Some config options are missing:
-  {'auth_url': None,
+  {'auth_host': None,
    'jump_host': None,
    'password_provider': 'prompt',
    'ssh_key_file': '~/.ssh/id_rsa.pub',
@@ -65,7 +65,7 @@
     File "*/cbas/configuration.py", line *, in is_complete (glob)
       'Some config options are missing:\n{0}'.format(self))
   cbas.configuration.MissingConfigValues: Some config options are missing:
-  {'auth_url': None,
+  {'auth_host': None,
    'jump_host': None,
    'password_provider': 'prompt',
    'ssh_key_file': '~/.ssh/id_rsa.pub',
@@ -83,7 +83,7 @@
 
   $ cbas -v upload
   Default config is:
-  {'auth_url': None,
+  {'auth_host': None,
    'jump_host': None,
    'password_provider': 'prompt',
    'ssh_key_file': '~/.ssh/id_rsa.pub',
@@ -125,7 +125,7 @@
   $ echo "ssh-key-file: from-config-file" > ~/.cbas
   $ cbas -v -k from-command-line -a url -h host dry_run
   Default config is:
-  {'auth_url': None,
+  {'auth_host': None,
    'jump_host': None,
    'password_provider': 'prompt',
    'ssh_key_file': '~/.ssh/id_rsa.pub',
@@ -134,19 +134,19 @@
   Loaded values from config file are:
   {'ssh_key_file': 'from-config-file'}
   Processed config after loading:
-  {'auth_url': None,
+  {'auth_host': None,
    'jump_host': None,
    'password_provider': 'prompt',
    'ssh_key_file': 'from-config-file',
    'username': '*'} (glob)
   Values supplied on the command-line are:
-  {'auth_url': u?'url', (re)
+  {'auth_host': u?'url', (re)
    'jump_host': u?'host', (re)
    'password_provider': None,
    'ssh_key_file': u?'from-command-line', (re)
    'username': None}
   Final aggregated config:
-  {'auth_url': u?'url', (re)
+  {'auth_host': u?'url', (re)
    'jump_host': u?'host', (re)
    'password_provider': 'prompt',
    'ssh_key_file': u?'from-command-line', (re)

--- a/src/cmdlinetest/test_cbas_verbose.t
+++ b/src/cmdlinetest/test_cbas_verbose.t
@@ -14,7 +14,7 @@
                                     '~/.ssh/id_rsa.pub'.
     -p, --password-provider <provider>
                                     Password provider. Default: 'prompt'.
-    -a, --auth-url <auth_url>       Auth-server URL.
+    -a, --auth-host <host>          Auth-server host.
     -h, --jump-host <host>          Jump host to connect with.
     --version                       Print version and exit.
     --help                          Show this message and exit.
@@ -35,7 +35,7 @@
 # Export the mock urls
 
   $ export JUMP_MOCK=http://localhost:8080
-  $ export AUTH_MOCK=http://localhost:8080/oauth/token
+  $ export AUTH_MOCK=http://localhost:8080
 
 # Make a test home
 
@@ -51,19 +51,19 @@
 
   $ cbas -v -u auth_fail -p testing -k pubkey.pub -h $JUMP_MOCK -a $AUTH_MOCK upload
   Default config is:
-  {'auth_url': None,
+  {'auth_host': None,
    'jump_host': None,
    'password_provider': 'prompt',
    'ssh_key_file': '~/.ssh/id_rsa.pub',
    'username': '*'} (glob)
   Values supplied on the command-line are:
-  {'auth_url': u?'http://localhost:8080/oauth/token', (re)
+  {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
    'password_provider': u?'testing', (re)
    'ssh_key_file': u?'pubkey.pub', (re)
    'username': u?'auth_fail'} (re)
   Final aggregated config:
-  {'auth_url': u?'http://localhost:8080/oauth/token', (re)
+  {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
    'password_provider': u?'testing', (re)
    'ssh_key_file': u?'pubkey.pub', (re)
@@ -104,19 +104,19 @@
 
   $ cbas -v -u user_ok -p testing -k pubkey.pub -h $JUMP_MOCK -a $AUTH_MOCK upload
   Default config is:
-  {'auth_url': None,
+  {'auth_host': None,
    'jump_host': None,
    'password_provider': 'prompt',
    'ssh_key_file': '~/.ssh/id_rsa.pub',
    'username': '*'} (glob)
   Values supplied on the command-line are:
-  {'auth_url': u?'http://localhost:8080/oauth/token', (re)
+  {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
    'password_provider': u?'testing', (re)
    'ssh_key_file': u?'pubkey.pub', (re)
    'username': u?'user_ok'} (re)
   Final aggregated config:
-  {'auth_url': u?'http://localhost:8080/oauth/token', (re)
+  {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
    'password_provider': u?'testing', (re)
    'ssh_key_file': u?'pubkey.pub', (re)
@@ -135,19 +135,19 @@
   $ echo "" >pubkey.pub
   $ cbas -v -u create_fail -p testing -k pubkey.pub -h $JUMP_MOCK -a $AUTH_MOCK upload
   Default config is:
-  {'auth_url': None,
+  {'auth_host': None,
    'jump_host': None,
    'password_provider': 'prompt',
    'ssh_key_file': '~/.ssh/id_rsa.pub',
    'username': '*'} (glob)
   Values supplied on the command-line are:
-  {'auth_url': u?'http://localhost:8080/oauth/token', (re)
+  {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
    'password_provider': u?'testing', (re)
    'ssh_key_file': u?'pubkey.pub', (re)
    'username': u?'create_fail'} (re)
   Final aggregated config:
-  {'auth_url': u?'http://localhost:8080/oauth/token', (re)
+  {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
    'password_provider': u?'testing', (re)
    'ssh_key_file': u?'pubkey.pub', (re)
@@ -189,19 +189,19 @@
 
   $ cbas -v -u user_ok -p testing -h $JUMP_MOCK -a $AUTH_MOCK delete
   Default config is:
-  {'auth_url': None,
+  {'auth_host': None,
    'jump_host': None,
    'password_provider': 'prompt',
    'ssh_key_file': '~/.ssh/id_rsa.pub',
    'username': '*'} (glob)
   Values supplied on the command-line are:
-  {'auth_url': u?'http://localhost:8080/oauth/token', (re)
+  {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
    'password_provider': u?'testing', (re)
    'ssh_key_file': None, (re)
    'username': u?'user_ok'} (re)
   Final aggregated config:
-  {'auth_url': u?'http://localhost:8080/oauth/token', (re)
+  {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
    'password_provider': u?'testing', (re)
    'ssh_key_file': '~/.ssh/id_rsa.pub',
@@ -219,19 +219,19 @@
 
   $ cbas -v -u delete_fail -p testing -h $JUMP_MOCK -a $AUTH_MOCK delete
   Default config is:
-  {'auth_url': None,
+  {'auth_host': None,
    'jump_host': None,
    'password_provider': 'prompt',
    'ssh_key_file': '~/.ssh/id_rsa.pub',
    'username': '*'} (glob)
   Values supplied on the command-line are:
-  {'auth_url': u?'http://localhost:8080/oauth/token', (re)
+  {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
    'password_provider': u?'testing', (re)
    'ssh_key_file': None, (re)
    'username': u?'delete_fail'} (re)
   Final aggregated config:
-  {'auth_url': u?'http://localhost:8080/oauth/token', (re)
+  {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
    'password_provider': u?'testing', (re)
    'ssh_key_file': '~/.ssh/id_rsa.pub',

--- a/src/main/python/cbas/auth_server.py
+++ b/src/main/python/cbas/auth_server.py
@@ -2,12 +2,19 @@ from cbas.log import verbose, info
 import cbas.log as log
 import requests
 
+from six.moves.urllib.parse import urlparse
+
 
 def get_auth_url(config):
-    if "://" in config.auth_host:
-        return '{0}/oauth/token'.format(config.auth_host)
-    else:
-        return 'https://{0}/oauth/token'.format(config.auth_host)
+    result = config.auth_host
+    # add the scheme if none exists
+    if "://" not in config.auth_host:
+        result = 'https://{0}'.format(result)
+    # add the endpoint if none exists
+    parsed = urlparse(result)
+    if not parsed.path:
+        result = '{0}/oauth/token'.format(result)
+    return result
 
 
 def obtain_access_token(config, password):

--- a/src/main/python/cbas/auth_server.py
+++ b/src/main/python/cbas/auth_server.py
@@ -3,14 +3,21 @@ import cbas.log as log
 import requests
 
 
+def get_auth_url(config):
+    if "://" in config.auth_host:
+        return '{0}/oauth/token'.format(config.auth_host)
+    else:
+        return 'https://{0}/oauth/token'.format(config.auth_host)
+
+
 def obtain_access_token(config, password):
     info("Will now attempt to obtain an JWT...")
     auth_request_data = {'client_id': 'jumpauth',
                          'username': config.username,
                          'password': password,
                          'grant_type': 'password'}
-
-    auth_response = requests.post(config.auth_url, auth_request_data)
+    auth_url = get_auth_url(config)
+    auth_response = requests.post(auth_url, auth_request_data)
 
     if auth_response.status_code not in [200, 201]:
         log.info("Authentication failed: {0}".

--- a/src/main/python/cbas/configuration.py
+++ b/src/main/python/cbas/configuration.py
@@ -26,7 +26,7 @@ class MissingConfigValues(Exception):
 
 class CBASConfig(collections.MutableMapping):
     options = {'username': lambda: getpass.getuser(),
-               'auth_url': None,
+               'auth_host': None,
                'password_provider': DEFAULT_PASSWORD_PROVIDER,
                'jump_host': None,
                'ssh_key_file': DEFAULT_SSH_KEY_FILE,

--- a/src/main/scripts/cbas
+++ b/src/main/scripts/cbas
@@ -69,9 +69,9 @@ def read_wrapper(ctx, param, value):
 @click.option('-p', '--password-provider',
               metavar='<provider>',
               help="Password provider. Default: 'prompt'.")
-@click.option('-a', '--auth-url',
-              metavar='<auth_url>',
-              help="Auth-server URL.")
+@click.option('-a', '--auth-host',
+              metavar='<host>',
+              help="Auth-server host.")
 @click.option('-h', '--jump-host',
               metavar='<host>',
               help="Jump host to connect with.")

--- a/src/unittest/python/auth_server_tests.py
+++ b/src/unittest/python/auth_server_tests.py
@@ -20,7 +20,7 @@ class TestObtainAccessToken(unittest.TestCase):
         rmock.post(requests_mock.ANY, text='{"access_token": "ANY_TOKEN"}')
         cmock = Mock()
         cmock.username = "ANY_USERNAME"
-        cmock.auth_url = "https://ANY_URL.example"
+        cmock.auth_host = "ANY_URL.example"
         result = obtain_access_token(cmock, 'ANY_PASSWORD')
         self.assertEqual('ANY_TOKEN', result)
         received_post_data = parse_qs(rmock.request_history[0].text)

--- a/src/unittest/python/auth_server_tests.py
+++ b/src/unittest/python/auth_server_tests.py
@@ -23,6 +23,11 @@ class TestGetAuthUrl(unittest.TestCase):
         m = Mock(auth_host='ANY_HOST')
         self.assertEqual('https://ANY_HOST/oauth/token', get_auth_url(m))
 
+    def test_ignore_path_if_exists(self):
+        m = Mock(auth_host='ANY_HOST/special/id/auth')
+        self.assertEqual('https://ANY_HOST/special/id/auth', get_auth_url(m))
+
+
 
 class TestObtainAccessToken(unittest.TestCase):
 

--- a/src/unittest/python/auth_server_tests.py
+++ b/src/unittest/python/auth_server_tests.py
@@ -5,12 +5,23 @@ from mock import Mock
 
 import requests_mock
 
-from cbas.auth_server import obtain_access_token
+from cbas.auth_server import obtain_access_token, get_auth_url
 
 if sys.version_info[0] == 3:
     from urllib.parse import parse_qs
 else:
     from urlparse import parse_qs
+
+
+class TestGetAuthUrl(unittest.TestCase):
+
+    def test_use_explicit_scheme(self):
+        m = Mock(auth_host='http://ANY_HOST')
+        self.assertEqual('http://ANY_HOST/oauth/token', get_auth_url(m))
+
+    def test_prefix_https(self):
+        m = Mock(auth_host='ANY_HOST')
+        self.assertEqual('https://ANY_HOST/oauth/token', get_auth_url(m))
 
 
 class TestObtainAccessToken(unittest.TestCase):

--- a/src/unittest/python/configuration_tests.py
+++ b/src/unittest/python/configuration_tests.py
@@ -9,7 +9,7 @@ class TestCBASConfig(unittest.TestCase):
     def test_default_initialization(self):
         config = CBASConfig()
         self.assertEqual(config.username, 'ANY_USER')
-        self.assertEqual(config.auth_url, None)
+        self.assertEqual(config.auth_host, None)
         self.assertEqual(config.password_provider, 'prompt')
         self.assertEqual(config.jump_host, None)
         self.assertEqual(config.ssh_key_file, '~/.ssh/id_rsa.pub')
@@ -18,7 +18,7 @@ class TestCBASConfig(unittest.TestCase):
     def test_str_defaults(self):
         received = CBASConfig()
         expected = {'username': 'ANY_USER',
-                    'auth_url': None,
+                    'auth_host': None,
                     'password_provider': 'prompt',
                     'jump_host': None,
                     'ssh_key_file': '~/.ssh/id_rsa.pub'}
@@ -30,13 +30,13 @@ class TestCBASConfig(unittest.TestCase):
         config = CBASConfig()
         to_inject = {
             'username': 'ANY_USER',
-            'auth_url': 'ANY_URL',
+            'auth_host': 'ANY_AUTH',
             'password_provider': 'ANY_PROVIDER',
             # exclude jump_host to make sure it remains None
         }
         config.inject(to_inject)
         self.assertEqual(config.username, 'ANY_USER')
-        self.assertEqual(config.auth_url, 'ANY_URL')
+        self.assertEqual(config.auth_host, 'ANY_AUTH')
         self.assertEqual(config.password_provider, 'ANY_PROVIDER')
         self.assertEqual(config.jump_host, None)
 
@@ -87,7 +87,7 @@ class TestCBASConfig(unittest.TestCase):
 
     def test_success_for_complete_config(self):
         complete_config = CBASConfig()
-        complete_config.auth_url = 'ANY_URL'
+        complete_config.auth_host = 'ANY_AUTH'
         complete_config.jump_host = 'ANY_HOST'
         self.assertTrue(complete_config.is_complete)
 


### PR DESCRIPTION
Simplify the way we handle the auth-server. By default, the user does not need a
protocol and the url-endpoint anymore. A specific scheme is supported for
testing/mocking purposes. This creates more symmetry between the jump-host and
auth-host parameters and is likely to be less confusing for the user.
