### PR TITLE
Show config in same YAML format as used in config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 htmlcov/
 *.t.err
 target/
-/venv
+/venv*
 /.idea
 /*.iml

--- a/src/cmdlinetest/test_cbas_config.t
+++ b/src/cmdlinetest/test_cbas_config.t
@@ -12,23 +12,30 @@
 # Test incomplete configuration
 
   $ cbas upload
-  Some config options are missing:
-  {'auth_host': None,
-   'jump_host': None,
-   'password_provider': 'prompt',
-   'ssh_key_file': '~/.ssh/id_rsa.pub',
-   'username': '*'} (glob)
+  ERROR: Some config options are missing, active config is:
+  ---
+  auth_host: null
+  jump_host: null
+  password_provider: prompt
+  ssh_key_file: ~/.ssh/id_rsa.pub
+  username: * (glob)
+  ...
+  
   [1]
+
 
 # Test incomplete configuration with verbose
 
   $ cbas -v upload 
   Default config is:
-  {'auth_host': None,
-   'jump_host': None,
-   'password_provider': 'prompt',
-   'ssh_key_file': '~/.ssh/id_rsa.pub',
-   'username': '*'} (glob)
+  ---
+  auth_host: null
+  jump_host: null
+  password_provider: prompt
+  ssh_key_file: ~/.ssh/id_rsa.pub
+  username: * (glob)
+  ...
+  
   Values supplied on the command-line are:
   {'auth_host': None,
    'jump_host': None,
@@ -36,84 +43,48 @@
    'ssh_key_file': None,
    'username': None}
   Final aggregated config:
-  {'auth_host': None,
-   'jump_host': None,
-   'password_provider': 'prompt',
-   'ssh_key_file': '~/.ssh/id_rsa.pub',
-   'username': '*'} (glob)
-  Some config options are missing:
-  {'auth_host': None,
-   'jump_host': None,
-   'password_provider': 'prompt',
-   'ssh_key_file': '~/.ssh/id_rsa.pub',
-   'username': '*'} (glob)
-  Traceback (most recent call last):
-    File "*/scripts/cbas", line *, in <module> (glob)
-      main()
-    File "*/site-packages/click/core.py", line *, in __call__ (glob)
-      return self.main(*args, **kwargs)
-    File "*/site-packages/click/core.py", line *, in main (glob)
-      rv = self.invoke(ctx)
-    File "*/site-packages/click/core.py", line *, in invoke (glob)
-      Command.invoke(self, ctx)
-    File "*/site-packages/click/core.py", line *, in invoke (glob)
-      return ctx.invoke(self.callback, **ctx.params)
-    File "*/site-packages/click/core.py", line *, in invoke (glob)
-      return callback(*args, **kwargs)
-    File "*/scripts/cbas", line *, in main (glob)
-      config.is_complete()
-    File "*/cbas/configuration.py", line *, in is_complete (glob)
-      'Some config options are missing:\n{0}'.format(self))
-  cbas.configuration.MissingConfigValues: Some config options are missing:
-  {'auth_host': None,
-   'jump_host': None,
-   'password_provider': 'prompt',
-   'ssh_key_file': '~/.ssh/id_rsa.pub',
-   'username': '*'} (glob)
+  ---
+  auth_host: null
+  jump_host: null
+  password_provider: prompt
+  ssh_key_file: ~/.ssh/id_rsa.pub
+  username: * (glob)
+  ...
+  
+  ERROR: Some config options are missing, active config is:
+  ---
+  auth_host: null
+  jump_host: null
+  password_provider: prompt
+  ssh_key_file: ~/.ssh/id_rsa.pub
+  username: * (glob)
+  ...
+  
   [1]
+
+
 
 # Test unexpected config values
 
   $ echo "UNEXPECTED_KEY: UNEXPECTED_VALUE" > ~/.cbas
   $ cbas upload
-  The following unexpected values were detected ['UNEXPECTED_KEY']
+  ERROR: The following unexpected options were detected in configuration: UNEXPECTED_KEY
   [1]
 
 # Test unexpected config values with verbose
 
   $ cbas -v upload
   Default config is:
-  {'auth_host': None,
-   'jump_host': None,
-   'password_provider': 'prompt',
-   'ssh_key_file': '~/.ssh/id_rsa.pub',
-   'username': '*'} (glob)
+  ---
+  auth_host: null
+  jump_host: null
+  password_provider: prompt
+  ssh_key_file: ~/.ssh/id_rsa.pub
+  username: * (glob)
+  ...
+  
   Config path is: test-home/.cbas
-  The following unexpected values were detected ['UNEXPECTED_KEY']
-  Traceback (most recent call last):
-    File "*/scripts/cbas", line *, in <module> (glob)
-      main()
-    File "*/site-packages/click/core.py", line *, in __call__ (glob)
-      return self.main(*args, **kwargs)
-    File "*/site-packages/click/core.py", line *, in main (glob)
-      with self.make_context(prog_name, args, **extra) as ctx:
-    File "*/site-packages/click/core.py", line *, in make_context (glob)
-      self.parse_args(ctx, args)
-    File "*/site-packages/click/core.py", line *, in parse_args (glob)
-      rest = Command.parse_args(self, ctx, args)
-    File "*/site-packages/click/core.py", line *, in parse_args (glob)
-      value, args = param.handle_parse_result(ctx, opts, args)
-    File "*/site-packages/click/core.py", line *, in handle_parse_result (glob)
-      self.callback, ctx, self, value)
-    File "*/site-packages/click/core.py", line *, in invoke_param_callback (glob)
-      return callback(ctx, param, value)
-    File "*/scripts/cbas", line *, in read_wrapper (glob)
-      return CBASConfig.read(ctx, param, value)
-    File "*/cbas/configuration.py", line *, in read (glob)
-      config.validate_options(loaded_config)
-    File "*/cbas/configuration.py", line *, in validate_options (glob)
-      'The following unexpected values were detected {0}'.format(list(unexpected_values)))
-  cbas.configuration.UnexpectedConfigValues: The following unexpected values were detected ['UNEXPECTED_KEY']
+  ERROR: The following unexpected options were detected in configuration: UNEXPECTED_KEY
   [1]
 
 # Cleanup
@@ -125,20 +96,29 @@
   $ echo "ssh-key-file: from-config-file" > ~/.cbas
   $ cbas -v -k from-command-line -a url -h host dry_run
   Default config is:
-  {'auth_host': None,
-   'jump_host': None,
-   'password_provider': 'prompt',
-   'ssh_key_file': '~/.ssh/id_rsa.pub',
-   'username': '*'} (glob)
+  ---
+  auth_host: null
+  jump_host: null
+  password_provider: prompt
+  ssh_key_file: ~/.ssh/id_rsa.pub
+  username: * (glob)
+  ...
+  
   Config path is: test-home/.cbas
   Loaded values from config file are:
-  {'ssh_key_file': 'from-config-file'}
+  ---
+  ssh_key_file: from-config-file
+  ...
+  
   Processed config after loading:
-  {'auth_host': None,
-   'jump_host': None,
-   'password_provider': 'prompt',
-   'ssh_key_file': 'from-config-file',
-   'username': '*'} (glob)
+  ---
+  auth_host: null
+  jump_host: null
+  password_provider: prompt
+  ssh_key_file: from-config-file
+  username: * (glob)
+  ...
+  
   Values supplied on the command-line are:
   {'auth_host': u?'url', (re)
    'jump_host': u?'host', (re)
@@ -146,8 +126,12 @@
    'ssh_key_file': u?'from-command-line', (re)
    'username': None}
   Final aggregated config:
-  {'auth_host': u?'url', (re)
-   'jump_host': u?'host', (re)
-   'password_provider': 'prompt',
-   'ssh_key_file': u?'from-command-line', (re)
-   'username': '*'} (glob)
+  ---
+  auth_host: url
+  jump_host: host
+  password_provider: prompt
+  ssh_key_file: from-command-line
+  username: * (glob)
+  ...
+  
+

--- a/src/cmdlinetest/test_cbas_verbose.t
+++ b/src/cmdlinetest/test_cbas_verbose.t
@@ -51,11 +51,14 @@
 
   $ cbas -v -u auth_fail -p testing -k pubkey.pub -h $JUMP_MOCK -a $AUTH_MOCK upload
   Default config is:
-  {'auth_host': None,
-   'jump_host': None,
-   'password_provider': 'prompt',
-   'ssh_key_file': '~/.ssh/id_rsa.pub',
-   'username': '*'} (glob)
+  ---
+  auth_host: null
+  jump_host: null
+  password_provider: prompt
+  ssh_key_file: ~/.ssh/id_rsa.pub
+  username: schlomo
+  ...
+  
   Values supplied on the command-line are:
   {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
@@ -63,11 +66,14 @@
    'ssh_key_file': u?'pubkey.pub', (re)
    'username': u?'auth_fail'} (re)
   Final aggregated config:
-  {'auth_host': u?'http://localhost:8080', (re)
-   'jump_host': u?'http://localhost:8080', (re)
-   'password_provider': u?'testing', (re)
-   'ssh_key_file': u?'pubkey.pub', (re)
-   'username': u?'auth_fail'} (re)
+  ---
+  auth_host: http://localhost:8080
+  jump_host: http://localhost:8080
+  password_provider: testing
+  ssh_key_file: pubkey.pub
+  username: auth_fail
+  ...
+  
   Password provider is: 'testing'
   Will now attempt to obtain an JWT...
   Authentication failed: errored with HTTP 400 on request
@@ -104,11 +110,14 @@
 
   $ cbas -v -u user_ok -p testing -k pubkey.pub -h $JUMP_MOCK -a $AUTH_MOCK upload
   Default config is:
-  {'auth_host': None,
-   'jump_host': None,
-   'password_provider': 'prompt',
-   'ssh_key_file': '~/.ssh/id_rsa.pub',
-   'username': '*'} (glob)
+  ---
+  auth_host: null
+  jump_host: null
+  password_provider: prompt
+  ssh_key_file: ~/.ssh/id_rsa.pub
+  username: schlomo
+  ...
+  
   Values supplied on the command-line are:
   {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
@@ -116,11 +125,14 @@
    'ssh_key_file': u?'pubkey.pub', (re)
    'username': u?'user_ok'} (re)
   Final aggregated config:
-  {'auth_host': u?'http://localhost:8080', (re)
-   'jump_host': u?'http://localhost:8080', (re)
-   'password_provider': u?'testing', (re)
-   'ssh_key_file': u?'pubkey.pub', (re)
-   'username': u?'user_ok'} (re)
+  ---
+  auth_host: http://localhost:8080
+  jump_host: http://localhost:8080
+  password_provider: testing
+  ssh_key_file: pubkey.pub
+  username: user_ok
+  ...
+  
   Password provider is: 'testing'
   Will now attempt to obtain an JWT...
   Authentication OK!
@@ -135,11 +147,14 @@
   $ echo "" >pubkey.pub
   $ cbas -v -u create_fail -p testing -k pubkey.pub -h $JUMP_MOCK -a $AUTH_MOCK upload
   Default config is:
-  {'auth_host': None,
-   'jump_host': None,
-   'password_provider': 'prompt',
-   'ssh_key_file': '~/.ssh/id_rsa.pub',
-   'username': '*'} (glob)
+  ---
+  auth_host: null
+  jump_host: null
+  password_provider: prompt
+  ssh_key_file: ~/.ssh/id_rsa.pub
+  username: schlomo
+  ...
+  
   Values supplied on the command-line are:
   {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
@@ -147,11 +162,14 @@
    'ssh_key_file': u?'pubkey.pub', (re)
    'username': u?'create_fail'} (re)
   Final aggregated config:
-  {'auth_host': u?'http://localhost:8080', (re)
-   'jump_host': u?'http://localhost:8080', (re)
-   'password_provider': u?'testing', (re)
-   'ssh_key_file': u?'pubkey.pub', (re)
-   'username': u?'create_fail'} (re)
+  ---
+  auth_host: http://localhost:8080
+  jump_host: http://localhost:8080
+  password_provider: testing
+  ssh_key_file: pubkey.pub
+  username: create_fail
+  ...
+  
   Password provider is: 'testing'
   Will now attempt to obtain an JWT...
   Authentication OK!
@@ -189,11 +207,14 @@
 
   $ cbas -v -u user_ok -p testing -h $JUMP_MOCK -a $AUTH_MOCK delete
   Default config is:
-  {'auth_host': None,
-   'jump_host': None,
-   'password_provider': 'prompt',
-   'ssh_key_file': '~/.ssh/id_rsa.pub',
-   'username': '*'} (glob)
+  ---
+  auth_host: null
+  jump_host: null
+  password_provider: prompt
+  ssh_key_file: ~/.ssh/id_rsa.pub
+  username: schlomo
+  ...
+  
   Values supplied on the command-line are:
   {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
@@ -201,11 +222,14 @@
    'ssh_key_file': None, (re)
    'username': u?'user_ok'} (re)
   Final aggregated config:
-  {'auth_host': u?'http://localhost:8080', (re)
-   'jump_host': u?'http://localhost:8080', (re)
-   'password_provider': u?'testing', (re)
-   'ssh_key_file': '~/.ssh/id_rsa.pub',
-   'username': u?'user_ok'} (re)
+  ---
+  auth_host: http://localhost:8080
+  jump_host: http://localhost:8080
+  password_provider: testing
+  ssh_key_file: ~/.ssh/id_rsa.pub
+  username: user_ok
+  ...
+  
   Password provider is: 'testing'
   Will now attempt to obtain an JWT...
   Authentication OK!
@@ -219,11 +243,14 @@
 
   $ cbas -v -u delete_fail -p testing -h $JUMP_MOCK -a $AUTH_MOCK delete
   Default config is:
-  {'auth_host': None,
-   'jump_host': None,
-   'password_provider': 'prompt',
-   'ssh_key_file': '~/.ssh/id_rsa.pub',
-   'username': '*'} (glob)
+  ---
+  auth_host: null
+  jump_host: null
+  password_provider: prompt
+  ssh_key_file: ~/.ssh/id_rsa.pub
+  username: schlomo
+  ...
+  
   Values supplied on the command-line are:
   {'auth_host': u?'http://localhost:8080', (re)
    'jump_host': u?'http://localhost:8080', (re)
@@ -231,11 +258,14 @@
    'ssh_key_file': None, (re)
    'username': u?'delete_fail'} (re)
   Final aggregated config:
-  {'auth_host': u?'http://localhost:8080', (re)
-   'jump_host': u?'http://localhost:8080', (re)
-   'password_provider': u?'testing', (re)
-   'ssh_key_file': '~/.ssh/id_rsa.pub',
-   'username': u?'delete_fail'} (re)
+  ---
+  auth_host: http://localhost:8080
+  jump_host: http://localhost:8080
+  password_provider: testing
+  ssh_key_file: ~/.ssh/id_rsa.pub
+  username: delete_fail
+  ...
+  
   Password provider is: 'testing'
   Will now attempt to obtain an JWT...
   Authentication OK!

--- a/src/cmdlinetest/test_cbas_verbose.t
+++ b/src/cmdlinetest/test_cbas_verbose.t
@@ -56,7 +56,7 @@
   jump_host: null
   password_provider: prompt
   ssh_key_file: ~/.ssh/id_rsa.pub
-  username: schlomo
+  username: * (glob)
   ...
   
   Values supplied on the command-line are:
@@ -115,7 +115,7 @@
   jump_host: null
   password_provider: prompt
   ssh_key_file: ~/.ssh/id_rsa.pub
-  username: schlomo
+  username: * (glob)
   ...
   
   Values supplied on the command-line are:
@@ -152,7 +152,7 @@
   jump_host: null
   password_provider: prompt
   ssh_key_file: ~/.ssh/id_rsa.pub
-  username: schlomo
+  username: * (glob)
   ...
   
   Values supplied on the command-line are:
@@ -212,7 +212,7 @@
   jump_host: null
   password_provider: prompt
   ssh_key_file: ~/.ssh/id_rsa.pub
-  username: schlomo
+  username: * (glob)
   ...
   
   Values supplied on the command-line are:
@@ -248,7 +248,7 @@
   jump_host: null
   password_provider: prompt
   ssh_key_file: ~/.ssh/id_rsa.pub
-  username: schlomo
+  username: * (glob)
   ...
   
   Values supplied on the command-line are:

--- a/src/main/scripts/cbas
+++ b/src/main/scripts/cbas
@@ -143,7 +143,7 @@ if __name__ == '__main__':
     try:
         main()
     except (MissingConfigValues, UnexpectedConfigValues) as e:
-        log.info("ERROR: {0}".format(e.message))
+        log.info("ERROR: {0}".format(e))
         sys.exit(1)
     except Exception as e:
         log.info(e)

--- a/src/main/scripts/cbas
+++ b/src/main/scripts/cbas
@@ -142,6 +142,9 @@ def dry_run(config):
 if __name__ == '__main__':
     try:
         main()
+    except (MissingConfigValues, UnexpectedConfigValues) as e:
+        log.info("ERROR: {0}".format(e.message))
+        sys.exit(1)
     except Exception as e:
         log.info(e)
         if log.VERBOSE:


### PR DESCRIPTION
Show config in same YAML format as expected in config file to allow copy-paste creation of config file.
Catch common errors without showing traceback.
